### PR TITLE
Handle the case where no stats are sent

### DIFF
--- a/django_statsd/panel.py
+++ b/django_statsd/panel.py
@@ -23,6 +23,9 @@ def munge(stats):
 
 def times(stats):
     results = []
+    if not stats:
+        return results
+
     start = stats[0][1]
     end = max([t[3] for t in stats])
     length = end - start


### PR DESCRIPTION
If there are no timing stats, we'll get an IndexError.
