### PR TITLE
Cope with non Tastypie URLs. 

### DIFF
--- a/django_statsd/middleware.py
+++ b/django_statsd/middleware.py
@@ -56,5 +56,5 @@ class TastyPieRequestTimingMiddleware(GraphiteRequestTimingMiddleware):
             request._view_module = view_kwargs['api_name']
             request._view_name = view_kwargs['resource_name']
             request._start_time = time.time()
-        except AttributeError:
+        except (AttributeError, KeyError):
             pass


### PR DESCRIPTION
Non Tastypie URLs do not have the 'api_name' key.
