### PR TITLE
Adding the statsd debug toolbar panel breaks the SQL details view.

### DIFF
--- a/django_statsd/templates/toolbar_statsd/statsd.html
+++ b/django_statsd/templates/toolbar_statsd/statsd.html
@@ -57,7 +57,7 @@
 </table>
 </section>
 
-<div id="graphs" img="graphite?width=586&amp;height=308&amp;target=root.key&amp;target=root.key.lower&amp;target=root.key.mean&amp;target=root.key.upper_90&amp;target=scale(root.key.count,0.1)&amp;from=-24hours&amp;title=24 hours" />
+<div id="graphs" img="graphite?width=586&amp;height=308&amp;target=root.key&amp;target=root.key.lower&amp;target=root.key.mean&amp;target=root.key.upper_90&amp;target=scale(root.key.count,0.1)&amp;from=-24hours&amp;title=24 hours"></div>
 
 <script type="text/javascript">
   // TODO: inlining is bad, this should be external.


### PR DESCRIPTION
also closes https://github.com/andymckay/django-statsd/issues/15
