### PR TITLE
Implement gauge

### DIFF
--- a/django_statsd/clients/log.py
+++ b/django_statsd/clients/log.py
@@ -1,12 +1,12 @@
 import logging
 
-from statsd.client import StatsClient
+from django_statsd.clients.null import StatsClient
 
 log = logging.getLogger('statsd')
 
 
 class StatsClient(StatsClient):
-    """A client that pushes things into a local cache."""
+    """A client that sends messages to the logging framework."""
 
     def timing(self, stat, delta, rate=1):
         """Send new timing information. `delta` is in milliseconds."""
@@ -19,3 +19,7 @@ class StatsClient(StatsClient):
     def decr(self, stat, count=1, rate=1):
         """Decrement a stat by `count`."""
         log.info('Decrement: %s, %s, %s' % (stat, count, rate))
+
+    def gauge(self, stat, value, rate=1):
+        """Set a gauge value."""
+        log.info('Gauge: %s, %s, %s' % (stat, value, rate))

--- a/django_statsd/clients/moz_metlog.py
+++ b/django_statsd/clients/moz_metlog.py
@@ -1,4 +1,4 @@
-from statsd.client import StatsClient
+from django_statsd.clients.null import StatsClient
 from django.conf import settings
 
 

--- a/django_statsd/clients/toolbar.py
+++ b/django_statsd/clients/toolbar.py
@@ -1,6 +1,6 @@
 from time import time
 
-from statsd.client import StatsClient
+from django_statsd.clients.null import StatsClient
 
 
 class StatsClient(StatsClient):
@@ -32,5 +32,7 @@ class StatsClient(StatsClient):
         self.cache.setdefault(stat, [])
         self.cache[stat].append([-count, rate])
 
-    def _send(self, stat, value, rate):
-        pass
+    def gauge(self, stat, value, rate=1):
+        """Set a gauge value."""
+        stat = '%s|gauge' % stat
+        self.cache[stat] = [[value, rate]]


### PR DESCRIPTION
The gauge() method was not implemented by the alternate clients. The logging client did not override _send, so calling gauge() with the logging client would actually end up sending the stat.

I implemented the gauge method, and changed the alternate clients to inherit from the null client, so there is less risk of accidentally sending stats to a real server when an alternate client is configured.
