### PR TITLE
Fix deprecation warnings

### DIFF
--- a/django_statsd/urls.py
+++ b/django_statsd/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError: # django < 1.4
+    from django.conf.urls.defaults import patterns, url
 
 urlpatterns = patterns('',
     url('^record$', 'django_statsd.views.record',


### PR DESCRIPTION
Django 1.4 moved utility functions from django.conf.urls.defaults to django.conf.urls, and deprecated the old module name.
