### PR TITLE
Javascript replace global switch doesn't work in Chrome

### DIFF
--- a/django_statsd/templates/toolbar_statsd/statsd.html
+++ b/django_statsd/templates/toolbar_statsd/statsd.html
@@ -77,9 +77,9 @@ $(document).ready(function() {
          }
          target.html('');
          $.each(roots, function(root) {
-            var custom = img.replace('graphite', graphite, 'g')
-                            .replace('root', roots[root], 'g')
-                            .replace('key', that.attr('data-key'), 'g');
+            var custom = img.replace(/graphite/g, graphite)
+                            .replace(/root/g, roots[root])
+                            .replace(/key/g, that.attr('data-key'));
                             target.append('<p><b>' + roots[root] + '.' + that.attr('data-key') + '</b></p><img src="' + custom + '">');
                             console.log(custom);
         })


### PR DESCRIPTION
The `replace()` switches are non-standard, it doesn't work in Chrome for example. The graphs in the debug toolbar don't show up because not all variables are replaced. If you use a regex instead it works in both Firefox and Chrome.
