### PR TITLE
Incorrect toolbar timings bar widths

### DIFF
--- a/django_statsd/clients/toolbar.py
+++ b/django_statsd/clients/toolbar.py
@@ -18,7 +18,7 @@ class StatsClient(StatsClient):
         """Send new timing information. `delta` is in milliseconds."""
         stat = '%s|timing' % stat
         now = time() * 1000
-        self.timings.append([stat, now, delta, now + delta])
+        self.timings.append([stat, now - delta, delta, now])
 
     def incr(self, stat, count=1, rate=1):
         """Increment a stat by `count`."""

--- a/django_statsd/panel.py
+++ b/django_statsd/panel.py
@@ -26,16 +26,23 @@ def times(stats):
     if not stats:
         return results
 
-    start = stats[0][1]
-    end = max([t[3] for t in stats])
-    length = end - start
-    for stat in stats:
-        results.append([stat[0].split('|')[0],
+    all_start = stats[0][1]
+    all_end = max([t[3] for t in stats])
+    all_duration = all_end - all_start
+    for stat, start, duration, end in stats:
+        start_rel = (start - all_start)
+        start_ratio = (start_rel / float(all_duration))
+        duration_ratio = (duration / float(all_duration))
+        try:
+            duration_ratio_relative = duration_ratio / (1.0 - start_ratio)
+        except ZeroDivisionError:
+            duration_ratio_relative = 0
+        results.append([stat.split('|')[0],
                         # % start from left.
-                        ((stat[1] - start - stat[2]) / float(length)) * 100,
-                        # % width.
-                        max(1, (stat[2] / float(length)) * 100),
-                        stat[2],
+                        start_ratio * 100.0,
+                        # % width
+                        duration_ratio_relative * 100.0,
+                        duration,
                         ])
     return results
 

--- a/django_statsd/templates/toolbar_statsd/statsd.html
+++ b/django_statsd/templates/toolbar_statsd/statsd.html
@@ -17,7 +17,7 @@
       <td class="timeline">
         <div class="djDebugTimeline">
           <div class="djDebugLineChart" style="left: {{ value.1 }}%;">
-            <strong style="width: {{ value.2 }}%; background: grey;">&nbsp;</strong>
+            <strong style="width: {{ value.2 }}%; min-width: 1px; background: grey;">&nbsp;</strong>
           </div>
       </div>
       </td>


### PR DESCRIPTION
They should be calculated relative to the remaining width, not the full width of the cell. With the current code, four timings of 250ms each would get smaller towards the end (25% of100%, 25% of 75%, 25% of 50%, 25% of 25%).

Also restructure the contents of the timers array, now it's `(stat, start, duration, end)`, not `(stat, end, duration, end + duration)`, which was probably an error.
