### PR TITLE
Toolbar timer summary

### DIFF
--- a/django_statsd/panel.py
+++ b/django_statsd/panel.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext_lazy as _, ungettext
 from debug_toolbar.panels import DebugPanel
 from django_statsd.clients import statsd
 
+from collections import defaultdict
 
 def munge(stats):
     # Munge the stats back into something easy for a template.
@@ -39,6 +40,32 @@ def times(stats):
                         ])
     return results
 
+def times_summary(stats):
+    results = []
+    if not stats:
+        return results
+
+    timings = defaultdict(list)
+    for stat in stats:
+        timings[stat[0].split('|')[0]].append(stat[2])
+
+    for stat, v in timings.iteritems():
+        if not v:
+            continue
+        v.sort()
+        count = len(v)
+        vmin, vmax = v[0], v[-1]
+        vsum = sum(v)
+        mean = vsum / float(count)
+        results.append({
+            'stat': stat,
+            'count': count,
+            'sum': vsum,
+            'lower': vmin,
+            'upper': vmax,
+            'mean': mean,
+            })
+    return results
 
 class StatsdPanel(DebugPanel):
 
@@ -76,4 +103,5 @@ class StatsdPanel(DebugPanel):
         context['graphite'] = config.get('graphite')
         context['statsd'] = munge(self.statsd.cache)
         context['timings'] = times(self.statsd.timings)
+        context['timings_summary'] = times_summary(self.statsd.timings)
         return render_to_string('toolbar_statsd/statsd.html', context)

--- a/django_statsd/templates/toolbar_statsd/statsd.html
+++ b/django_statsd/templates/toolbar_statsd/statsd.html
@@ -2,6 +2,30 @@
   data-graphite="{{ graphite }}"
   data-roots-timers="{% for root in timers %}{{ root }}{% if not forloop.last %}|{% endif %}{% endfor %}"
   data-roots-counts="{% for root in counts %}{{ root }}{% if not forloop.last %}|{% endif %}{% endfor %}">
+<table id="timings-summary">
+  <thead>
+    <tr>
+      <th>Stat</th>
+      <th>count</th>
+      <th>sum</th>
+      <th>lower</th>
+      <th>mean</th>
+      <th>upper</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for value in timings_summary %}
+    <tr>
+      <td><a href="#" class="statsd" data-key="{{ value.stat }}" data-type="timing">{{ value.stat }}</a></td>
+      <td>{{ value.count }}</td>
+      <td>{{ value.sum }}</td>
+      <td>{{ value.lower }}</td>
+      <td>{{ value.mean|floatformat:"2" }}</td>
+      <td>{{ value.upper }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
 <table id="timings">
   <thead>
     <tr>


### PR DESCRIPTION
A summary table, giving the count, sum, lower, mean and upper values of each timer. Sort of what you will get in StatsD, but summarized for this single page.
