### PR TITLE
Move "count" in toolbar graph to right axis

### DIFF
--- a/django_statsd/templates/toolbar_statsd/statsd.html
+++ b/django_statsd/templates/toolbar_statsd/statsd.html
@@ -57,7 +57,7 @@
 </table>
 </section>
 
-<div id="graphs" img="graphite?width=586&amp;height=308&amp;target=root.key&amp;target=root.key.lower&amp;target=root.key.mean&amp;target=root.key.upper_90&amp;target=scale(root.key.count,0.1)&amp;from=-24hours&amp;title=24 hours"></div>
+<div id="graphs" img="graphite?width=586&amp;height=308&amp;target=alias(secondYAxis(summarize(root.key.count, '60sec')), 'Count per minute')&amp;target=aliasByMetric(root.key)&amp;target=aliasByMetric(root.key.lower)&amp;target=aliasByMetric(root.key.mean)&amp;target=aliasByMetric(root.key.upper_90)&amp;from=-24hours&amp;title=24 hours"></div>
 
 <script type="text/javascript">
   // TODO: inlining is bad, this should be external.


### PR DESCRIPTION
Because it's a different metric, and the default scale of 10% doesn't make sense for every environment. By putting it first in the list it is draw below the actual timing graphs. Also contains nicer labels.

I have also summarized it per 60 seconds because graphs from other sources (server logs) are calculated per minute, but this could be converted to an option.
