### PR TITLE
Comparison bars for timing toolbar

### DIFF
--- a/django_statsd/panel.py
+++ b/django_statsd/panel.py
@@ -37,6 +37,7 @@ def times(stats):
                         max(1, (stat[2] / float(length)) * 100),
                         stat[2],
                         ])
+    results.sort(key=lambda r: r[1])
     return results
 
 

--- a/django_statsd/templates/toolbar_statsd/statsd.html
+++ b/django_statsd/templates/toolbar_statsd/statsd.html
@@ -2,31 +2,33 @@
   data-graphite="{{ graphite }}"
   data-roots-timers="{% for root in timers %}{{ root }}{% if not forloop.last %}|{% endif %}{% endfor %}"
   data-roots-counts="{% for root in counts %}{{ root }}{% if not forloop.last %}|{% endif %}{% endfor %}">
-<table id="timings">
+<table id="timings" style="display: table">
   <thead>
     <tr>
       <th>Stat</th>
-      <th class="timeline">Timing</th>
-      <th>Time</th>
+      <th>Time (ms)</th>
+      <th class="timeline" style="width: 99%">Timing</th>
     </tr>
   </thead>
   <tbody>
     {% for value in timings %}
     <tr>
       <td><a href="#" class="statsd" data-key="{{ value.0 }}" data-type="timing">{{ value.0 }}</a></td>
+      <td>{{ value.3 }}</td>
       <td class="timeline">
         <div class="djDebugTimeline">
-          <div class="djDebugLineChart" style="left: {{ value.1 }}%;">
+          <div class="djDebugLineChart djDebugLineChartSlave">
+            <strong style="background: lightgrey; width: 0">&nbsp;</strong>
+          </div>
+          <div class="djDebugLineChart djDebugLineChartActual" style="left: {{ value.1 }}%;">
             <strong style="width: {{ value.2 }}%; background: grey;">&nbsp;</strong>
           </div>
       </div>
       </td>
-      <td>{{ value.3 }}ms</td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
-
 <table>
   <thead>
     <tr>
@@ -84,6 +86,16 @@ $(document).ready(function() {
                             console.log(custom);
         })
       });
+
+      $('#djDebugStatsdPanel #timings td').click(function() {
+         var currentRow = $(this).parent(),
+             currentLine = currentRow.find('.djDebugLineChartActual'),
+             currentBar = currentLine.children('strong'),
+             table = currentLine.closest('table'),
+             barLeft = currentLine.position().left,
+             barWidth = currentBar.width();
+         table.find('.djDebugLineChartSlave').css('left', barLeft).find('strong').css('width', barWidth);
+              });
 })
 </script>
 


### PR DESCRIPTION
Click on a timing and you see the "ghost" bars in the other rows, showing you what happened at the same time. Also sort the rows by the start time, not the end time.
