### PR TITLE
Optionally skip extra timing details.

### DIFF
--- a/django_statsd/middleware.py
+++ b/django_statsd/middleware.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.http import Http404
 from django_statsd.clients import statsd
 import inspect
@@ -46,8 +47,9 @@ class GraphiteRequestTimingMiddleware(object):
             data = dict(module=request._view_module, name=request._view_name,
                         method=request.method)
             statsd.timing('view.{module}.{name}.{method}'.format(**data), ms)
-            statsd.timing('view.{module}.{method}'.format(**data), ms)
-            statsd.timing('view.{method}'.format(**data), ms)
+            if getattr(settings, 'STATSD_VIEW_TIMER_DETAILS', True):
+                statsd.timing('view.{module}.{method}'.format(**data), ms)
+                statsd.timing('view.{method}'.format(**data), ms)
 
 
 class TastyPieRequestTimingMiddleware(GraphiteRequestTimingMiddleware):


### PR DESCRIPTION
These can generate a ton of data and, honestly, I don't why they're important. This defaults to keeping the behavior as is but lets you opt out.