### PR TITLE
Make TastyPieRequestTimingMiddleware fallback to GraphiteRequestTimingMiddleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.py[co]
 build
 dist
+mydatabase

--- a/django_statsd/middleware.py
+++ b/django_statsd/middleware.py
@@ -59,4 +59,5 @@ class TastyPieRequestTimingMiddleware(GraphiteRequestTimingMiddleware):
             request._view_name = view_kwargs['resource_name']
             request._start_time = time.time()
         except (AttributeError, KeyError):
-            pass
+            super(TastyPieRequestTimingMiddleware, self).process_view(request,
+                view_func, view_args, view_kwargs)

--- a/django_statsd/tests.py
+++ b/django_statsd/tests.py
@@ -113,6 +113,31 @@ class TestTiming(unittest.TestCase):
         for expected, (args, kwargs) in zip(names, timing.call_args_list):
             eq_(expected, args[0])
 
+    def test_request_timing_tastypie(self, timing):
+        func = lambda x: x
+        gmw = middleware.TastyPieRequestTimingMiddleware()
+        gmw.process_view(self.req, func, tuple(), {'api_name': 'my_api_name',
+            'resource_name': 'my_resource_name'})
+        gmw.process_response(self.req, self.res)
+        eq_(timing.call_count, 3)
+        names = ['view.my_api_name.my_resource_name.GET',
+                 'view.my_api_name.GET',
+                 'view.GET']
+        for expected, (args, kwargs) in zip(names, timing.call_args_list):
+            eq_(expected, args[0])
+
+    def test_request_timing_tastypie_fallback(self, timing):
+        func = lambda x: x
+        gmw = middleware.TastyPieRequestTimingMiddleware()
+        gmw.process_view(self.req, func, tuple(), dict())
+        gmw.process_response(self.req, self.res)
+        eq_(timing.call_count, 3)
+        names = ['view.%s.%s.GET' % (func.__module__, func.__name__),
+                 'view.%s.GET' % func.__module__,
+                 'view.GET']
+        for expected, (args, kwargs) in zip(names, timing.call_args_list):
+            eq_(expected, args[0])
+
 
 class TestClient(unittest.TestCase):
 


### PR DESCRIPTION
`TastyPieRequestTimingMiddleware` shouldn't just do nothing if it couldn't find tastypie-specific info, instead it should just fall back to the parent's implementation, `GraphiteRequestTimingMiddleware`.
