### PR TITLE
Fix TypeError at /services/timing/record

### DIFF
--- a/django_statsd/views.py
+++ b/django_statsd/views.py
@@ -89,7 +89,7 @@ def _process_boomerang(request):
 
     keys = {}
     for k in getattr(settings, 'STATSD_RECORD_KEYS', stick_keys):
-        v = request.GET.get(boomerang[k])
+        v = int(request.GET.get(boomerang[k]))
         if not v or v == 'undefined':
             continue
         if k in boomerang:


### PR DESCRIPTION
Got TypeError when using with boomerang. It turns out that params are not coerced properly before feeding to _process_summaries function.

```
TypeError at /services/timing/record
unsupported operand type(s) for -: 'unicode' and 'long'
Request Method: GET
Request URL:    http://127.0.0.1:8000/services/timing/record?client=boomerang&rt.start=navigation&rt.tstart=1395546368776&rt.bstart=1395546372614&rt.end=1395546375459&t_resp=1106&t_page=5577&t_done=6683&r=&t_other=boomerang%7C41%2Cboomr_fb%7C3838%2Ct_domloaded%7C4208&nt_red_cnt=0&nt_nav_type=0&nt_nav_st=1395546368776&nt_red_st=0&nt_red_end=0&nt_fet_st=1395546368927&nt_dns_st=1395546368927&nt_dns_end=1395546368927&nt_con_st=1395546368927&nt_con_end=1395546368927&nt_req_st=1395546368947&nt_res_st=1395546369882&nt_res_end=1395546370000&nt_domloading=1395546370022&nt_domint=1395546372839&nt_domcontloaded_st=1395546372839&nt_domcontloaded_end=1395546372984&nt_domcomp=1395546375371&nt_load_st=1395546375371&nt_load_end=1395546375448&nt_unload_st=0&nt_unload_end=0&nt_spdy=0&nt_first_paint=1395546371.725609&v=0.9&u=http%3A%2F%2F127.0.0.1%3A8000%2Fshanghai%2F
Django Version: 1.4
Exception Type: TypeError
Exception Value:    
unsupported operand type(s) for -: 'unicode' and 'long'
Exception Location: /home/tom/.virtualenvs/cw/local/lib/python2.7/site-packages/django_statsd/views.py in _process_summaries, line 65
Python Executable:  /home/tom/.virtualenvs/cw/bin/python
Python Version: 2.7.4
```
