### PR TITLE
Bugfix: counters for boomerang are not casted to int

### DIFF
--- a/django_statsd/views.py
+++ b/django_statsd/views.py
@@ -94,7 +94,7 @@ def _process_boomerang(request):
             continue
         if k in boomerang:
             process_key(start, k, v)
-            keys[k] = v
+            keys[k] = int(v)
 
     try:
         _process_summaries(start, keys)


### PR DESCRIPTION
When processing boomerang data, views.process_summaries fails, as
variables in "keys" dictionary are unicode objects. All values should be
timestamps from navigation timing, so casting is safe.
