### PR TITLE
Fix issue where db timings were not being patched properly for django 1.6

### DIFF
--- a/django_statsd/patches/utils.py
+++ b/django_statsd/patches/utils.py
@@ -1,6 +1,19 @@
 from django_statsd.clients import statsd
-from functools import partial
+from functools import partial, wraps
 
+def patch_method(target, name, external_decorator=None):
+
+    def decorator(patch_function):
+        original_function = getattr(target, name)
+
+        @wraps(patch_function)
+        def wrapper(*args, **kw):
+            return patch_function(original_function, *args, **kw)
+
+        setattr(target, name, wrapper)
+        return wrapper
+
+    return decorator
 
 def wrapped(method, key, *args, **kw):
     with statsd.timer(key):


### PR DESCRIPTION
The __getattr__ method previously implemented in django_statsd.patches.db does not function the same as CursorWrapper.__getattr__ in django 1.6. This is causing db timings to not be populated when DEBUG = False.

I ended up just making wrap_class generic enough to account for CursorDebugWrapper and CursorWrapper, as I feel it is a cleaner implementation. This also eliminates the partial() creation on each execute/executemany call.

I tested this against django 1.5.1 and 1.6.3, both worked as expected.

Thank you very much for this module, it is immensely useful.
