### PR TITLE
Updated StatsdPanel class to use django-debug-toolbar > 1.0 panel api

### DIFF
--- a/django_statsd/panel.py
+++ b/django_statsd/panel.py
@@ -1,8 +1,7 @@
 from django.conf import settings
-from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _, ungettext
 
-from debug_toolbar.panels import DebugPanel
+from debug_toolbar.panels import Panel
 from django_statsd.clients import statsd
 
 
@@ -47,13 +46,15 @@ def times(stats):
     return results
 
 
-class StatsdPanel(DebugPanel):
+class StatsdPanel(Panel):
 
-    name = 'Statsd'
+    title = _('Statsd')
     has_content = True
 
-    def __init__(self, *args, **kw):
-        super(StatsdPanel, self).__init__(*args, **kw)
+    template = 'toolbar_statsd/statsd.html'
+
+    def __init__(self, *args, **kwargs):
+        super(StatsdPanel, self).__init__(*args, **kwargs)
         self.statsd = statsd
         try:
             self.statsd.reset()
@@ -61,26 +62,19 @@ class StatsdPanel(DebugPanel):
             raise ValueError('To use the toolbar, your STATSD_CLIENT must'
                              'be set to django_statsd.clients.toolbar')
 
-    def nav_title(self):
-        return _('Statsd')
-
+    @property
     def nav_subtitle(self):
         length = len(self.statsd.cache) + len(self.statsd.timings)
         return ungettext('%s record', '%s records', length) % length
 
-    def title(self):
-        return _('Statsd')
-
-    def url(self):
-        return ''
-
-    def content(self):
-        context = self.context.copy()
+    def process_response(self, request, response):
         config = getattr(settings, 'TOOLBAR_STATSD', {})
         if 'roots' in config:
             for key in ['timers', 'counts']:
-                context[key] = config['roots'][key]
-        context['graphite'] = config.get('graphite')
-        context['statsd'] = munge(self.statsd.cache)
-        context['timings'] = times(self.statsd.timings)
-        return render_to_string('toolbar_statsd/statsd.html', context)
+                self.record_stats({key: config['roots'][key]})
+
+        self.record_stats({
+            'graphite': config.get('graphite'),
+            'statsd': munge(self.statsd.cache),
+            'timings': times(self.statsd.timings)
+        })


### PR DESCRIPTION
Fixes bug where django-statsd debug panel does not show. Fixes issue #60
