### PR TITLE
Fix error in Python 3

### DIFF
--- a/django_statsd/tests.py
+++ b/django_statsd/tests.py
@@ -5,7 +5,12 @@ import sys
 from django.conf import settings
 from nose.exc import SkipTest
 from nose import tools as nose_tools
-from unittest2 import skipUnless
+try:
+    # Python 2.7, Python 3.x
+    from unittest import skipUnless
+except ImportError:
+    # Python 2.6
+    from unittest2 import skipUnless
 
 from django import VERSION
 from django.core.urlresolvers import reverse


### PR DESCRIPTION
``` python
(.env) ~/D/django-statsd (master|✔) $ nosetests
E
======================================================================
ERROR: Failure: ImportError (No module named unittest2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/loader.py", line 413, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/local/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/local/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/coreyf/Development/django-statsd/django_statsd/tests.py", line 8, in <module>
    from unittest2 import skipUnless
ImportError: No module named unittest2

----------------------------------------------------------------------
Ran 1 test in 0.017s

FAILED (errors=1)
```
