### PR TITLE
fix deprecation warnings for util

### DIFF
--- a/django_statsd/patches/db.py
+++ b/django_statsd/patches/db.py
@@ -1,5 +1,8 @@
 import django
-from django.db.backends import util
+try:
+    from django.db.backends import utils as util
+except ImportError:
+    from django.db.backends import util
 
 from django_statsd.patches.utils import wrap, patch_method
 from django_statsd.clients import statsd


### PR DESCRIPTION
The django.db.backends.util package has been renamed to django.db.backends.utils. The old util package will be removed in Django 1.9.

This fix works with all versions (prefers the new package) and removes depreciation warnings.