### PR TITLE
Fix deprecation warnings for util

### DIFF
--- a/django_statsd/clients/__init__.py
+++ b/django_statsd/clients/__init__.py
@@ -1,6 +1,10 @@
 import socket
 
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
+
 from django.conf import settings
 
 _statsd = None

--- a/django_statsd/patches/__init__.py
+++ b/django_statsd/patches/__init__.py
@@ -1,5 +1,9 @@
 from django.conf import settings
-from django.utils.importlib import import_module
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 patches = getattr(settings, 'STATSD_PATCHES', [])
 

--- a/django_statsd/patches/db.py
+++ b/django_statsd/patches/db.py
@@ -1,5 +1,8 @@
 import django
-from django.db.backends import util
+try:
+    from django.db.backends import utils as util
+except ImportError:
+    from django.db.backends import util
 
 from django_statsd.patches.utils import wrap, patch_method
 from django_statsd.clients import statsd

--- a/django_statsd/tests.py
+++ b/django_statsd/tests.py
@@ -537,8 +537,10 @@ class TestCursorWrapperPatching(TestCase):
                                     executemany,
                                     _getattr):
         try:
+            from django.db.backends import utils as util
+        except ImportError:
             from django.db.backends import util
-
+        try:
             # We need to patch CursorWrapper like this because setting
             # __getattr__ on Mock instances raises AttributeError.
             class CursorWrapper(object):


### PR DESCRIPTION
The django.db.backends.util package has been renamed to django.db.backends.utils. The old util package will be removed in Django 1.9.

This fix works with all versions (prefers the new package) and removes depreciation warnings.