### PR TITLE
Add Python 3.7 and Django 2.1 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,19 +16,37 @@ env:
     - DJANGO=1.10
     - DJANGO=1.11
     - DJANGO=2.0
+    - DJANGO=2.1
     - DJANGO=master
 
 matrix:
     fast_finish: true
+    include:
+      - python: "3.7"
+        env: DJANGO=2.0
+        sudo: required
+        dist: xenial
+      - python: "3.7"
+        env: DJANGO=2.1
+        sudo: required
+        dist: xenial
+      - python: "3.7"
+        env: DJANGO=master
+        sudo: required
+        dist: xenial
     exclude:
       - python: "2.7"
         env: DJANGO=master
       - python: "2.7"
         env: DJANGO=2.0
+      - python: "2.7"
+        env: DJANGO=2.1
       - python: "3.4"
         env: DJANGO=master
       - python: "3.4"
         env: DJANGO=2.0
+      - python: "3.4"
+        env: DJANGO=2.1
       - python: "3.6"
         env: DJANGO=1.8
       - python: "3.6"

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ envlist =
        {py27,py33,py34,py35,pypy,pypy3}-django18,
        {py27,py34,py35,pypy,pypy3}-django{19,110},
        {py27,py34,py35,py36,pypy,pypy3}-django111,
-       {py35,py36,pypy,pypy3}-djangomaster
+       py34-django20
+       {py35,py36,py37,pypy,pypy3}-django{20,21,master}
 
 [travis:env]
 DJANGO =
@@ -14,6 +15,8 @@ DJANGO =
     1.9: django19
     1.10: django110
     1.11: django111
+    2.0: django20
+    2.1: django21
     master: djangomaster
 
 [testenv]
@@ -28,5 +31,7 @@ deps =
         django19: Django>=1.9,<1.10
         django110: Django>=1.10,<1.11
         django111: Django>=1.11,<2.0
+        django20: Django>=2.0,<2.1
+        django21: Django>=2.1,<2.2
         djangomaster: https://github.com/django/django/archive/master.tar.gz
         -rrequirements.txt


### PR DESCRIPTION
For now travis requires `sudo: required` and `dist: xenial` for Python 3.7 to work.  (instead of Python 3.7-dev)  See travis-ci/travis-ci#9815 for details