### PR TITLE
added the check for the case where user is none - ie auth not attempted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist
 mydatabase
 .tox
 django_statsd_mozilla.egg-info
+venv/
+.idea/
+.python-version

--- a/django_statsd/middleware.py
+++ b/django_statsd/middleware.py
@@ -25,14 +25,14 @@ class GraphiteMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         statsd.incr('response.%s' % response.status_code)
-        if hasattr(request, 'user') and is_authenticated(request.user):
+        if hasattr(request, 'user') and request.user and is_authenticated(request.user):
             statsd.incr('response.auth.%s' % response.status_code)
         return response
 
     def process_exception(self, request, exception):
         if not isinstance(exception, Http404):
             statsd.incr('response.500')
-            if hasattr(request, 'user') and is_authenticated(request.user):
+            if hasattr(request, 'user') and request.user and is_authenticated(request.user):
                 statsd.incr('response.auth.500')
 
 

--- a/tests/test_django_statsd.py
+++ b/tests/test_django_statsd.py
@@ -107,6 +107,11 @@ class TestIncr(TestCase):
         gmw.process_exception(self.req, None)
         eq_(incr.call_count, 2)
 
+    def test_graphite_exception_authenticated_user_is_none(self, incr):
+        self.req.user = None
+        gmw = middleware.GraphiteMiddleware()
+        gmw.process_exception(self.req, None)
+        eq_(incr.call_count, 1)
 
 @mock.patch.object(middleware.statsd, 'timing')
 class TestTiming(unittest.TestCase):


### PR DESCRIPTION
Hi!

There is a case when the request has the user attribute present, but it is `None` - when the auth was not attempted although request did pass through a middleware. 

This PR would prevent the middleware from throwing errors in this case.

For reference: https://www.django-rest-framework.org/api-guide/authentication/#custom-authentication