### PR TITLE
Switch to time.perf_counter when it is available

### DIFF
--- a/django_statsd/celery.py
+++ b/django_statsd/celery.py
@@ -2,6 +2,14 @@ from __future__ import absolute_import
 from django_statsd.clients import statsd
 import time
 
+# Use timer that's not susceptible to time of day adjustments.
+try:
+    # perf_counter is only present on Py3.3+
+    from time import perf_counter as time_now
+except ImportError:
+    # fall back to using time
+    from time import time as time_now
+
 _task_start_times = {}
 
 
@@ -21,7 +29,7 @@ def on_task_prerun(sender=None, task_id=None, task=None, **kwds):
     statsd.incr('celery.%s.start' % task.name)
 
     # Keep track of start times. (For logging the duration in the postrun.)
-    _task_start_times[task_id] = time.time()
+    _task_start_times[task_id] = time_now()
 
 
 def on_task_postrun(sender=None, task_id=None, task=None, **kwds):
@@ -34,7 +42,7 @@ def on_task_postrun(sender=None, task_id=None, task=None, **kwds):
     # Log duration.
     start_time = _task_start_times.pop(task_id, False)
     if start_time:
-        ms = int((time.time() - start_time) * 1000)
+        ms = int((time_now() - start_time) * 1000)
         statsd.timing('celery.%s.runtime' % task.name, ms)
 
 


### PR DESCRIPTION
- Used code from statsd, but could have imported from https://github.com/jsocol/pystatsd/projects
  if version not frozen in requirements